### PR TITLE
fixed bug with hover color is equal to background color

### DIFF
--- a/webapp/src/pages/ui/dashboard/index.tsx
+++ b/webapp/src/pages/ui/dashboard/index.tsx
@@ -41,6 +41,9 @@ const DashboardPage = () => {
               fontSize: '14px',
               fontWeight: 'bold',
               padding: '10px 20px',
+              '&:hover': {
+                backgroundColor: theme.palette.secondary.dark,
+              },
             }}
           >
             <DownloadOutlined sx={{ marginRight: '10px' }} />


### PR DESCRIPTION
This PR fixes a bug where the background color of the button on the main page was the same as the background.